### PR TITLE
Force the use of lualatex

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,6 +1,7 @@
 % Template created by Markus Haug <mh@haugmarkus.com>
 % Credits: Markus Haug and the template contributors.
 % Feel free to share and modify this template, but please give credit where it's due.
+%!TEX program = lualatex
 
 \documentclass{article}[11pt, a4paper, oneside, ngerman]
 


### PR DESCRIPTION
This change force the use of lualatex because default is pdflatex.

You must enable magic comments.

Example for vscode to enable magic comments:
```
"latex-workshop.latex.build.forceRecipeUsage": false
```
