### PR TITLE
Zeilenabstand 1.5, Seitennummern bleiben Arabisch, entf. sample.bib

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -12,7 +12,7 @@
 \usepackage[hidelinks]{hyperref} % Hyperlinks ohne Umrandungen
 \usepackage{setspace} % Abstände zwischen Absätzen
 \usepackage[left=2cm, right=2cm, top=2cm, bottom=2cm]{geometry} % Seitenränder
-\onehalfspacing % 1,5 Zeilenabstand
+\setstretch{1.5} % 1,5 Zeilenabstand
 \usepackage{lipsum}  % Dummy-Texte
 \usepackage{titlesec} % define size for section headings
 \usepackage[nohyperlinks, printonlyused]{acronym} % Abkürzungen
@@ -194,7 +194,6 @@
 
 %% Bibliographie einbinden
 \addbibresource{references.bib} % your bib file
-\addbibresource{biblatex-examples.bib} % TODO: remove sample bib 
 
 
 %% ++++++++++++++++++++++++++++++++++++++++++
@@ -252,8 +251,6 @@
 \blankpage
 
 \phantomsection
-\pagenumbering{Roman} % Uppercase Roman numerals
-\setcounter{page}{5}
 % set bibliography name
 \renewcommand{\bibname}{Literaturverzeichnis}
 \addcontentsline{toc}{section}{\bibname}

--- a/references.bib
+++ b/references.bib
@@ -9,3 +9,73 @@
   doi = {10.1109/ACCESS.2022.3152803},
   file = {/Users/markus/Zotero/storage/VYH38M62/Grzegorz Blinowski et al. - 2022 - Monolithic vs. Microservice Architecture A Perfor.pdf}
 }
+
+@article{sigfridsson,
+  author       = {Sigfridsson, Emma and Ryde, Ulf},
+  title        = {Comparison of methods for deriving atomic charges from the
+                  electrostatic potential and moments},
+  journaltitle = {Journal of Computational Chemistry},
+  date         = 1998,
+  volume       = 19,
+  number       = 4,
+  pages        = {377-395},
+  doi          = {10.1002/(SICI)1096-987X(199803)19:4<377::AID-JCC1>3.0.CO;2-P},
+  langid       = {english},
+  langidopts   = {variant=american},
+  indextitle   = {Methods for deriving atomic charges},
+  annotation   = {An \texttt{article} entry with \texttt{volume},
+                  \texttt{number}, and \texttt{doi} fields. Note that the
+                  \textsc{doi} is transformed into a clickable link if
+                  \texttt{hyperref} support has been enabled},
+  abstract     = {Four methods for deriving partial atomic charges from the
+                  quantum chemical electrostatic potential (CHELP, CHELPG,
+                  Merz-Kollman, and RESP) have been compared and critically
+                  evaluated. It is shown that charges strongly depend on how and
+                  where the potential points are selected. Two alternative
+                  methods are suggested to avoid the arbitrariness in the
+                  point-selection schemes and van der Waals exclusion radii:
+                  CHELP-BOW, which also estimates the charges from the
+                  electrostatic potential, but with potential points that are
+                  Boltzmann-weighted after their occurrence in actual
+                  simulations using the energy function of the program in which
+                  the charges will be used, and CHELMO, which estimates the
+                  charges directly from the electrostatic multipole
+                  moments. Different criteria for the quality of the charges are
+                  discussed.},
+}
+
+
+@book{nussbaum,
+  author       = {Nussbaum, Martha},
+  title        = {Aristotle's \mkbibquote{De Motu Animalium}},
+  date         = 1978,
+  publisher    = pup,
+  location     = {Princeton},
+  keywords     = {secondary},
+  langid       = {english},
+  langidopts   = {variant=american},
+  sorttitle    = {Aristotle's De Motu Animalium},
+  indexsorttitle= {Aristotle's De Motu Animalium},
+  annotation   = {A \texttt{book} entry. Note the \texttt{sorttitle} and
+                  \texttt{indexsorttitle} fields and the markup of the quotes in
+                  the database file},
+}
+
+@thesis{geer,
+  author       = {de Geer, Ingrid},
+  title        = {Earl, Saint, Bishop, Skald~-- and Music},
+  type         = {phdthesis},
+  institution  = {Uppsala Universitet},
+  date         = 1985,
+  subtitle     = {The {Orkney Earldom} of the Twelfth Century. {A} Musicological
+                  Study},
+  location     = {Uppsala},
+  options      = {useprefix=false},
+  langid       = {english},
+  langidopts   = {variant=british},
+  annotation   = {This is a typical \texttt{thesis} entry for a PhD thesis. Note
+                  the \texttt{type} field in the database file which uses a
+                  localization key. Also note the format of the printed name and
+                  compare the \texttt{useprefix} option in the \texttt{options}
+                  field as well as \texttt{vangennep}},
+}


### PR DESCRIPTION
\setstretch{1.5} entspricht dem 1.5 Zeilenabstand von MS Word.
Siehe [Stackexchange](https://tex.stackexchange.com/a/682778/319228)

Arabische Nummern werden bis zum Ende durchgezogen:
`Diese Seitenzahlen werden bis zum Schluss, also auch durch den Anhang hindurch (falls vorhanden), weitergeführt.`

Kompletter Text aus dem Prüfungsleitfaden Fallstudie:
```
Außer dem Titelblatt sind alle Seiten zu nummerieren. Die Seiten vor dem Textteil (falls
vorhanden, z. B. Titelblatt, Inhaltsverzeichnis, Tabellen- und Abkürzungsverzeichnis) sollten
mit römischen Großbuchstaben nummeriert werden (I, II, III, IV etc.), wobei die Seitenzählung
auf der Seite I (Titelblatt) nicht erscheint. Die Seiten des Textteils werden mit arabischen
Zahlen (1, 2, 3 etc.) nummeriert. Diese Seitenzahlen werden bis zum Schluss, also auch durch
den Anhang hindurch (falls vorhanden), weitergeführt.
```